### PR TITLE
[feat] 로그인 및 회원가입 API Response Body id값 추가

### DIFF
--- a/member/serializers.py
+++ b/member/serializers.py
@@ -25,7 +25,8 @@ class MemberSerializer(serializers.ModelSerializer):
             )
             return member
         except IntegrityError as e:
-            raise serializers.ValidationError({"login_id": "This login_id is already in use."})
+            existing_member = Member.objects.get(login_id=validated_data['login_id'])
+            return existing_member
 
 class MemberDetailSerializer(serializers.ModelSerializer):
     class Meta:

--- a/member/views.py
+++ b/member/views.py
@@ -339,10 +339,12 @@ class MemberLoginView(APIView):
         operation_description="이 API는 사용자 로그인을 처리하는 데 사용됩니다.",
         request_body=MemberLoginSerializer,
         responses={
-            200: openapi.Response(
+            201: openapi.Response(
                 description="로그인 성공",
                 examples={
                     "application/json": {
+                        "id": 0,
+                        "username": "string",
                         "code": "A002",
                         "status": 201,
                         "message": "로그인 성공"
@@ -366,13 +368,16 @@ class MemberLoginView(APIView):
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         serializer = MemberLoginSerializer(data=request.data)
         if serializer.is_valid():
+            member = Member.objects.get(login_id=serializer.validated_data['login_id'])
             response_data = {
+                "id": member.id,
+                "username": member.nickname,
                 "code": "A002",
-                "status": 200,
+                "status": 201,
                 "message": "로그인 성공"
             }
-            logger.info(f'INFO {client_ip} {current_time} POST /members/login 200 login success')
-            return Response(response_data, status=200)
+            logger.info(f'INFO {client_ip} {current_time} POST /members/login 201 login success')
+            return Response(response_data, status=201)
         response_data = {
             "code": "A002_1",
             "status": 400,


### PR DESCRIPTION
### 🚀 Summary
로그인 및 회원가입 API Response Body id값 추가
<!-- A brief description of the issue. -->

---

### ✨ Description
로그인 및 회원가입 API Response Body id, username값 추가했습니다.
<!-- write down the work details and show the execution results. -->
{
  "id": 0,
  "username": "string",
  "code": "A001",
  "status": 201,
  "message": "회원가입 성공"
}

이제 이런식으로 response body를 뱉을겁니다!

추가적으로 id가 겹쳐서 회원가입을 실패하는 예외 처리도 해 주었습니다.

---

### 🎲 Issue Number

<!-- Please enter {Issue Number} below to automatically close the connected issue. -->

close #54 
